### PR TITLE
Cleanup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,50 @@ TODO
 
 TODO
 
+## API
+
+All API methods can be called via HTTP requests, and try to follow RESTful conventions except as noted.
+
+All responses are in JSON format, wrapped in a JSON envelope of the following form.
+
+```
+{
+    "response": <response from method, typically a list or object>
+    "meta": {
+        "count": <number of results in `response`>
+    }
+    "error": { // Or null, if no errors
+        "message": "Error message"
+    }
+}
+```
+
+### `GET` convos/
+
+Retrieves all parent conversations
+
+### `POST` convos/
+
+Create a new conversation
+
+### `GET` convos/:id/
+
+Retrieves an individual conversation
+
+### `PATCH` convos/:id/
+
+Edits an existing conversation. Will only change the fields that are passed to it. Only certain fields can be edited:
+
+Body?
+
+### `DELETE` convos/:id/
+
+Deletes an individual conversation and all conversations that have this conversation as a parent.
+
+### `POST` convos/:id/reply/
+
+Create a reply to an individual conversation
+
 ## Notes
 
 TODO

--- a/convos.go
+++ b/convos.go
@@ -24,10 +24,11 @@ func main() {
 	// TODO: Fix trailing slashes
 	m.Group("/convos", func(r martini.Router) {
 		r.Get("/", handlers.GetConvos)
-		r.Get("/:id/", handlers.GetConvo)
 		r.Post("/", handlers.CreateConvo)
-		r.Patch("/:id/", handlers.UpdateConvo)  // Generally, edits aren't allowed. Restrict this to updating the status...
+		r.Get("/:id/", handlers.GetConvo)
+		r.Patch("/:id/", handlers.UpdateConvo)
 		r.Delete("/:id/", handlers.DeleteConvo)
+		r.Post("/:id/reply/", handlers.CreateConvo)
 	})
 
 	log.Printf("listening on %v\n", httpPort)

--- a/db/errors.go
+++ b/db/errors.go
@@ -1,0 +1,16 @@
+package db
+
+type DBError string
+
+func (e DBError) Error() string {
+	return string(e)
+}
+
+const (
+	ErrConnection DBError = "DB Connection"
+	ErrRowScan    DBError = "Row Scan"
+	ErrRowUnknown DBError = "Row Unknown"
+	ErrRowDelete  DBError = "Row Delete"
+	ErrRowCreate  DBError = "Row Create"
+	ErrRowUpdate  DBError = "Row Update"
+)

--- a/handlers/json_envelope.go
+++ b/handlers/json_envelope.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"encoding/json"
+	"reflect"
+	"strconv"
+)
+
+type JsonEnvelope struct {
+	Response interface{}       `json:"response"`
+	Meta     map[string]string `json:"meta"`
+	Error    interface{}       `json:"error"`
+}
+
+func (e *JsonEnvelope) ToJson() string {
+	json, _ := json.Marshal(e.Response)
+	return string(json)
+}
+
+func getCount(obj interface{}) int {
+	var count int
+
+	switch reflect.TypeOf(obj).Kind() {
+	case reflect.Slice:
+		count = reflect.ValueOf(obj).Len()
+	default:
+		count = 1
+	}
+
+	return count
+}
+
+func getMeta(objs interface{}) map[string]string {
+	count := getCount(objs)
+	return map[string]string{"count": strconv.Itoa(count)}
+}
+
+func NewJsonEnvelope(objs interface{}, meta map[string]string, error interface{}) JsonEnvelope {
+	return JsonEnvelope{
+		Response: objs,
+		Meta:     meta,
+		Error:    error,
+	}
+}
+
+func NewJsonEnvelopeFromObj(objs interface{}) JsonEnvelope {
+	return NewJsonEnvelope(objs, getMeta(objs), nil)
+}
+
+func NewJsonEnvelopeFromError(err error) JsonEnvelope {
+	var errors []map[string]string
+
+	error := map[string]string{
+		"message": err.Error(),
+	}
+	errors = append(errors, error)
+
+	meta := map[string]string{"count": "1"}
+
+	return NewJsonEnvelope("", meta, errors)
+}


### PR DESCRIPTION
- Added rough documentation
- Added helper method, `reply`, to reply to conversation
- Added JSON envelope
- Improved Error Handling
- Implemented Patch method
- Have Create-like methods (e.g. PATCH and POST) return DB object through the magic of `Returning`
