### PR TITLE
Fix Subject Sharing

### DIFF
--- a/handlers/convo_handler.go
+++ b/handlers/convo_handler.go
@@ -81,12 +81,19 @@ func CreateConvo(req *http.Request, params martini.Params, r render.Render) {
 		return
 	}
 
-	// For now, just suppress the error
+	// For now, just suppress the conversion error
 	id, _ := strconv.Atoi(params["id"])
 	if id > 0 {
-		// TODO: Need to get Subject from parent...
-		// TODO: What if parent does not exist?
 		convo.Parent = id
+
+		// This incurs an extra DB call, but it seems like the simplest course of action to maintain the subject
+		parent, err := db.GetConvo(params["id"])
+		if err != nil {
+			r.JSON(500, NewJsonEnvelopeFromError(err))
+			return
+		}
+
+		convo.Subject = parent.Subject
 	}
 
 	// TODO: Need to return the saved object from the DB...

--- a/handlers/json_envelope.go
+++ b/handlers/json_envelope.go
@@ -48,14 +48,11 @@ func NewJsonEnvelopeFromObj(objs interface{}) JsonEnvelope {
 }
 
 func NewJsonEnvelopeFromError(err error) JsonEnvelope {
-	var errors []map[string]string
-
 	error := map[string]string{
 		"message": err.Error(),
 	}
-	errors = append(errors, error)
 
 	meta := map[string]string{"count": "1"}
 
-	return NewJsonEnvelope("", meta, errors)
+	return NewJsonEnvelope("", meta, error)
 }


### PR DESCRIPTION
According to the spec, replies should have the same subject. For simplicity, when we create a child object, we make an extra call (to the parent) to get the subject, and use that for the subject of the child message.

This PR also includes fixes for providing the parent id in other areas
