### PR TITLE
Add Pseudo-Authorization

### DIFF
--- a/convos.go
+++ b/convos.go
@@ -18,10 +18,8 @@ func main() {
 
 	// Add additional middleware
 	m.Use(render.Renderer())
-	// TODO: Add "Authorization" middleware that restricts user access to their convos
 
 	// Define Routes
-	// TODO: Fix trailing slashes
 	m.Group("/convos", func(r martini.Router) {
 		r.Get("/", handlers.GetConvos)
 		r.Post("/", handlers.CreateConvo)
@@ -29,7 +27,7 @@ func main() {
 		r.Patch("/:id/", handlers.UpdateConvo)
 		r.Delete("/:id/", handlers.DeleteConvo)
 		r.Post("/:id/reply/", handlers.CreateConvo)
-	})
+	}, handlers.UserAuthorizationMiddleware)
 
 	log.Printf("listening on %v\n", httpPort)
 	httpAddr := fmt.Sprintf(":%d", httpPort)

--- a/handlers/authorization_middleware.go
+++ b/handlers/authorization_middleware.go
@@ -1,0 +1,17 @@
+package handlers
+
+import (
+	"net/http"
+)
+
+func UserAuthorizationMiddleware(req *http.Request) {
+	// This isn't a real authorization middleware.
+	// It will act like one, in the sense that if will look for some key,
+	// and use it to restrict access to certain resources
+	userKey := req.Header.Get("X-USER-API-KEY")
+	if userKey != "" {
+		userId = userKey
+	} else {
+		userId = "0"
+	}
+}

--- a/handlers/convo_handler.go
+++ b/handlers/convo_handler.go
@@ -11,6 +11,10 @@ import (
 	"github.com/nt3rp/convos/db"
 )
 
+var (
+	userId string = "0"
+)
+
 func returnEnvelope(r render.Render, obj interface{}, err error) {
 	// We are able to distinguish between multiple error types,
 	// but for all the errors we have, they indicate an internal server error
@@ -46,19 +50,19 @@ func getJsonFromRequest(req *http.Request) (map[string]string, error) {
 }
 
 func GetConvos(r render.Render) {
-	convos, err := db.GetConvos()
+	convos, err := db.GetConvos(userId)
 	returnEnvelope(r, convos, err)
 }
 
 func GetConvo(params martini.Params, r render.Render) {
 	id := params["id"]
-	convo, err := db.GetConvo(id)
+	convo, err := db.GetConvo(userId, id)
 	returnEnvelope(r, convo, err)
 }
 
 func DeleteConvo(params martini.Params, r render.Render) {
 	id := params["id"]
-	err := db.DeleteConvo(id)
+	err := db.DeleteConvo(userId, id)
 	returnEnvelope(r, "success", err)
 }
 
@@ -71,7 +75,7 @@ func UpdateConvo(req *http.Request, params martini.Params, r render.Render) {
 	}
 
 	id := params["id"]
-	convo, err := db.UpdateConvo(id, patch["body"])
+	convo, err := db.UpdateConvo(userId, id, patch["body"])
 	returnEnvelope(r, convo, err)
 }
 
@@ -89,7 +93,7 @@ func CreateConvo(req *http.Request, params martini.Params, r render.Render) {
 		convo.Parent = id
 
 		// This incurs an extra DB call, but it seems like the simplest course of action to maintain the subject
-		parent, err := db.GetConvo(params["id"])
+		parent, err := db.GetConvo(userId, params["id"])
 		if err != nil {
 			returnEnvelope(r, convo, err)
 			return
@@ -99,7 +103,7 @@ func CreateConvo(req *http.Request, params martini.Params, r render.Render) {
 	}
 
 	// TODO: Need to return the saved object from the DB...
-	newConvo, err := db.CreateConvo(convo)
+	newConvo, err := db.CreateConvo(userId, convo)
 
 	returnEnvelope(r, newConvo, err)
 }


### PR DESCRIPTION
Returns a 404 when user is not a sender or recipient of a message when getting / updating / deleting, etc.

Normally, we would return a 403, but we avoid this for two reasons:
- It is easier to keep the API consistent
- The user doesn't need to know about resources they don't have access to (and shouldn't have access to)
