### PR TITLE
Added Read Status

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -7,11 +7,12 @@ func (e DBError) Error() string {
 }
 
 const (
-	ErrConnection DBError = "DB Connection"
-	ErrRowScan    DBError = "Row Scan"
-	ErrRowUnknown DBError = "Row Unknown"
-	ErrRowDelete  DBError = "Row Delete"
-	ErrRowCreate  DBError = "Row Create"
-	ErrRowUpdate  DBError = "Row Update"
-	ErrNoRows     DBError = "No Rows Found"
+	ErrConnection  DBError = "DB Connection"
+	ErrRowScan     DBError = "Row Scan"
+	ErrRowUnknown  DBError = "Row Unknown"
+	ErrRowDelete   DBError = "Row Delete"
+	ErrRowCreate   DBError = "Row Create"
+	ErrRowUpdate   DBError = "Row Update"
+	ErrNoRows      DBError = "No Rows Found"
+	ErrTransaction DBError = "Transaction Problem"
 )

--- a/handlers/convo_handler.go
+++ b/handlers/convo_handler.go
@@ -16,9 +16,6 @@ var (
 )
 
 func returnEnvelope(r render.Render, obj interface{}, err error) {
-	// We are able to distinguish between multiple error types,
-	// but for all the errors we have, they indicate an internal server error
-
 	switch errgo.Cause(err) {
 	case nil:
 		// We could issue more specific http status codes for 'ok' (especially when creating objects)
@@ -26,6 +23,16 @@ func returnEnvelope(r render.Render, obj interface{}, err error) {
 		r.JSON(http.StatusOK, NewJsonEnvelopeFromObj(obj))
 	case db.ErrNoRows:
 		r.JSON(http.StatusNotFound, NewJsonEnvelopeFromError(err))
+	case db.ErrRowScan:
+		fallthrough
+	case db.ErrRowUnknown:
+		fallthrough
+	case db.ErrRowDelete:
+		fallthrough
+	case db.ErrRowCreate:
+		fallthrough
+	case db.ErrRowUpdate:
+		r.JSON(http.StatusBadRequest, NewJsonEnvelopeFromError(err))
 	default:
 		r.JSON(http.StatusInternalServerError, NewJsonEnvelopeFromError(err))
 	}

--- a/migrations/0002_read_thread_table.down.sql
+++ b/migrations/0002_read_thread_table.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE read_status;
+ALTER TABLE convos DROP CONSTRAINT "convos_recipient_id_fkey";
+ALTER TABLE convos DROP CONSTRAINT "convos_sender_id_fkey";
+DROP TABLE users;

--- a/migrations/0002_read_thread_table.up.sql
+++ b/migrations/0002_read_thread_table.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS users (
+  id  INTEGER NOT NULL  PRIMARY KEY,
+  fullname VARCHAR(255)
+);
+
+CREATE TABLE read_status (
+  thread_id  INTEGER  NOT NULL           REFERENCES convos(id) ON DELETE CASCADE,
+  user_id    INTEGER  DEFAULT 0 NOT NULL REFERENCES users(id) ON DELETE SET DEFAULT
+);
+
+ALTER TABLE convos ADD FOREIGN KEY (recipient_id) REFERENCES users(id);
+ALTER TABLE convos ADD FOREIGN KEY (sender_id) REFERENCES users(id);


### PR DESCRIPTION
- `Bad Request` instead of `Server Error` when integrity constraint fails
- Add read status to all get, create, and update methods
- Change update behaviour: Only allow updating the read status (via `read` patch)
